### PR TITLE
Implement Google Analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -48,6 +48,13 @@ module.exports = {
         display: `minimal-ui`,
         icon: path.join(__dirname, `src/assets/images/icon.png`) // This path is relative to the root of the site.
       }
+    },
+    {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: process.env.ANALYTICS_KEY,
+        cookieDomain: process.env.ANALYTICS_DOMAIN
+      }
     }
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -52,8 +52,8 @@ module.exports = {
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
-        trackingId: process.env.ANALYTICS_KEY,
-        cookieDomain: process.env.ANALYTICS_DOMAIN
+        trackingId: 'UA-135888476-1',
+        cookieDomain: 'webconf.tech'
       }
     }
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gatsby-plugin-sass": "^2.0.0-rc.2",
     "gatsby-plugin-sharp": "^2.0.20",
     "gatsby-plugin-styled-components": "^3.0.5",
+    "gatsby-plugin-google-analytics": "^2.0.16",
     "husky": "^1.3.1",
     "node-sass": "^4.11.0",
     "node-sass-chokidar": "^1.3.4",

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { OutboundLink } from 'gatsby-plugin-google-analytics';
 import { CTALeafLike } from 'lib';
 import { SocialNetworkLinks } from 'components/SocialNetworkLinks';
 import { CFP } from 'data/constants';
@@ -7,7 +8,7 @@ import styles from './styles.module.scss';
 export const Footer = () => (
   <div className={styles.container}>
     <div>
-      <CTALeafLike href={CFP.url} title={CFP.title} target="_blank">
+      <CTALeafLike href={CFP.url} title={CFP.title} as={OutboundLink} target="_blank">
         {CFP.title}
       </CTALeafLike>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4807,6 +4807,13 @@ gatsby-link@^2.0.10:
     "@types/reach__router" "^1.0.0"
     prop-types "^15.6.1"
 
+gatsby-plugin-google-analytics@^2.0.16:
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.0.16.tgz#92e2f4c145cae75fe6d828d3fced89ccd70a1813"
+  integrity sha512-xJNcDZzBjtsHBm+uEMv8dJEvOg5XXnVJQmHgEn4NoYp+nByIGWPL13o579lIiaoOcgSRZX0Yek3qpaUFDyWpzQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 gatsby-plugin-manifest@^2.0.17:
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.0.17.tgz#1e2c3329b1a58bdf77186866dd9e94da54ac6e68"


### PR DESCRIPTION
### What does this PR do?

Implements [Gatsby's Google Analytics plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/).

~~The key and the domain come from environment variables, not sure if it's the best approach, so feel free to suggest another way. I didn't add them on a constant, even if the plugin only runs on production, because the settings are sent on build time.~~ Nvm, everything is hardcoded.

### How should it be tested manually?

1. `yarn build`/`npm run build`
2. `cd public`
3. Bring up an http server there.
4. You should see the requests for GA.

> If you are on mac or have Python installed, you can run this:
> 
> ```sh
> python -m SimpleHTTPServer
> ```

### TODOs

- [x] ~~Get the key and add it to the build step environment variables (the domain should be hardcoded to `webconf.tech`.~~