### PR TITLE
Track email form events

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+## What does this PR do?
+
+## How should it be tested manually?

--- a/src/common/ga.js
+++ b/src/common/ga.js
@@ -1,25 +1,23 @@
 import { waitForGlobal } from './utils';
 
 let client;
-const getClient = () => {
+const getClient = async () => {
   if (client) {
     return Promise.resolve(client);
   }
 
-  return waitForGlobal('ga').then(gaClient => {
-    client = gaClient;
-    return client;
-  });
+  const gaClient = await waitForGlobal('ga');
+  client = gaClient;
+  return client;
 };
 
-export const trackEvent = (category, action, label, value) => {
+export const trackEvent = async (category, action, label, value) => {
   if (process.env.NODE_ENV === 'production') {
-    getClient()
-      .then(gaClient => {
-        gaClient('send', 'event', category, action, label, value);
-      })
-      .catch(error => {
-        console.error('Unable to track event:', error.message);
-      });
+    try {
+      const gaClient = await getClient();
+      gaClient('send', 'event', category, action, label, value);
+    } catch (error) {
+      console.error('Unable to track event:', error.message);
+    }
   }
 };

--- a/src/common/ga.js
+++ b/src/common/ga.js
@@ -1,0 +1,25 @@
+import { waitForGlobal } from './utils';
+
+let client;
+const getClient = () => {
+  if (client) {
+    return Promise.resolve(client);
+  }
+
+  return waitForGlobal('ga').then(gaClient => {
+    client = gaClient;
+    return client;
+  });
+};
+
+export const trackEvent = (category, action, label, value) => {
+  if (process.env.NODE_ENV === 'production') {
+    getClient()
+      .then(gaClient => {
+        gaClient('send', 'event', category, action, label, value);
+      })
+      .catch(error => {
+        console.error('Unable to track event:', error.message);
+      });
+  }
+};

--- a/src/common/ga.js
+++ b/src/common/ga.js
@@ -12,12 +12,14 @@ const getClient = async () => {
 };
 
 export const trackEvent = async (category, action, label, value) => {
-  if (process.env.NODE_ENV === 'production') {
-    try {
-      const gaClient = await getClient();
-      gaClient('send', 'event', category, action, label, value);
-    } catch (error) {
-      console.error('Unable to track event:', error.message);
-    }
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  try {
+    const gaClient = await getClient();
+    gaClient('send', 'event', category, action, label, value);
+  } catch (error) {
+    console.error('Unable to track event:', error.message);
   }
 };

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,0 +1,33 @@
+export const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((presolve, preject) => {
+    resolve = presolve;
+    reject = preject;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject
+  };
+};
+
+export const waitForGlobal = (name, intervalTime = 600, attempts = 5) => {
+  const defer = deferred();
+  let currentAttempt = 0;
+  let interval = setInterval(() => {
+    currentAttempt++;
+    if (global[name]) {
+      defer.resolve(global[name]);
+      clearInterval(interval);
+      interval = null;
+    } else if (currentAttempt === attempts) {
+      defer.reject(new Error(`Missing global '${name}'`));
+      clearInterval(interval);
+      interval = null;
+    }
+  }, intervalTime);
+
+  return defer.promise;
+};

--- a/src/components/AddEmailForm/AddEmailForm.jsx
+++ b/src/components/AddEmailForm/AddEmailForm.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { addEmail } from 'data/email/actions';
 import { isAddingEmail, wasTheEmailSaved, emailError } from 'data/email/selectors';
 import { addEmailSchema } from 'data/email/schemas';
+import { trackEvent } from 'common/ga';
 import { Input, ValidationError, Button } from 'lib';
 import styles from './styles.module.scss';
 
@@ -30,41 +31,53 @@ const _AddEmailForm = ({ emailError, isAdding, wasSaved, add }) => {
   );
 
   const formErrors = emailError ? [emailError] : errors;
+  if (formErrors && formErrors.length) {
+    const [firstError] = formErrors;
+    trackEvent('emailForm', 'send', 'error', firstError);
+  }
 
-  return wasSaved ? (
-    <div className={`${styles.container} ${styles.NoMargin}`}>
-      <div className={styles.success}>
-        <h3 className={styles.title}>¡Todo listo!</h3>
-        <p className={styles.text}>Pronto te estaremos escribiendo.</p>
+  let render;
+  if (wasSaved) {
+    trackEvent('emailForm', 'send', 'success');
+    render = (
+      <div className={`${styles.container} ${styles.NoMargin}`}>
+        <div className={styles.success}>
+          <h3 className={styles.title}>¡Todo listo!</h3>
+          <p className={styles.text}>Pronto te estaremos escribiendo.</p>
+        </div>
       </div>
-    </div>
-  ) : (
-    <div className={styles.container}>
-      <p className={styles.title}>Dejanos tu e-mail y enterate al instante de las novedades!</p>
-      <form className={styles.form} onSubmit={onSubmit}>
-        <Input
-          placeholder="Tu e-mail"
-          value={email}
-          onChange={e => setEmail(e.target.value)}
-          hasError={!!formErrors}
-          disabled={isAdding}
-          autoFocus
-        />
-        {!!formErrors
-          ? formErrors.map(error => <ValidationError key={error}>{error}</ValidationError>)
-          : null}
-        <Button
-          type="submit"
-          color="secondary"
-          isLoading={isAdding}
-          disabled={isAdding}
-          className={styles.button}
-        >
-          Registrarme
-        </Button>
-      </form>
-    </div>
-  );
+    );
+  } else {
+    render = (
+      <div className={styles.container}>
+        <p className={styles.title}>Dejanos tu e-mail y enterate al instante de las novedades!</p>
+        <form className={styles.form} onSubmit={onSubmit}>
+          <Input
+            placeholder="Tu e-mail"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            hasError={!!formErrors}
+            disabled={isAdding}
+            autoFocus
+          />
+          {!!formErrors
+            ? formErrors.map(error => <ValidationError key={error}>{error}</ValidationError>)
+            : null}
+          <Button
+            type="submit"
+            color="secondary"
+            isLoading={isAdding}
+            disabled={isAdding}
+            className={styles.button}
+          >
+            Registrarme
+          </Button>
+        </form>
+      </div>
+    );
+  }
+
+  return render;
 };
 
 _AddEmailForm.displayName = 'AddEmailForm';

--- a/src/components/AddEmailForm/AddEmailForm.jsx
+++ b/src/components/AddEmailForm/AddEmailForm.jsx
@@ -30,8 +30,8 @@ const _AddEmailForm = ({ emailError, isAdding, wasSaved, add }) => {
     [email, setErrors, add]
   );
 
-  const formErrors = emailError ? [emailError] : errors;
-  if (formErrors && formErrors.length) {
+  const formErrors = [...(emailError || errors || [])];
+  if (formErrors.length) {
     const [firstError] = formErrors;
     trackEvent('emailForm', 'send', 'error', firstError);
   }
@@ -56,13 +56,13 @@ const _AddEmailForm = ({ emailError, isAdding, wasSaved, add }) => {
             placeholder="Tu e-mail"
             value={email}
             onChange={e => setEmail(e.target.value)}
-            hasError={!!formErrors}
+            hasError={!!formErrors.length}
             disabled={isAdding}
             autoFocus
           />
-          {!!formErrors
-            ? formErrors.map(error => <ValidationError key={error}>{error}</ValidationError>)
-            : null}
+          {formErrors.map(error => (
+            <ValidationError key={error}>{error}</ValidationError>
+          ))}
           <Button
             type="submit"
             color="secondary"


### PR DESCRIPTION
## What does this PR do?

TL;DR: The email form now tracks whenever the user gets an error and when the address is successfully saved.

I first added a `utils` _"service"_ with two functions I needed in order to access the the global `ga` for the event tracking:

- `deferred`: To get a promise that can be resolved _externally_. It's basically a native port of [this](https://api.jquery.com/jquery.deferred/).
- `waitForGlobal`: Uses `setInterval` and a deferred promise to wait for a global variable. This is useful for 3rd parties libraries that are not installed or that can't be accessed through a module.

Then I added a `trackEvent` function that basically uses `waitForGlobal` to get the Analytics client (`ga`), with caching in the middle (of course), and uses it to send a custom custom event. This function only works on `process.env.NODE_ENV === 'production'` because that's the same condition the Gatsby plugin for GA has. On development, the function doesn't do anything.

Finally, I set the email form to track when there are validation/api errors and when the email is successfully saved.

PD: I added a tiny PR template, if anyone has an objection, I can remove it, no worries.

## How should it be tested manually?

First, let's test that this doesn't work on development:

```sh
yarn start
```

1. Go to `http://localhost:8000/`.
2. Open the networks tab.
2. Write an invalid email address and try to register it, nothing should happen.

Now, let's try it for real:

1. `yarn build`/`npm run build`
2. `cd public`
3. Bring up an http server there.
4. Open the networks tab.
5. Write an invalid email address and try to register it, you should see the GA request.

> If you are on mac or have Python installed, you can run this:
> 
> ```sh
> python -m SimpleHTTPServer
> ```