### PR TITLE
Speakers section

### DIFF
--- a/lib/SpeakerGrid/Speaker.jsx
+++ b/lib/SpeakerGrid/Speaker.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { transparentize } from 'polished';
+import TwitterIcon from 'assets/icons/twitter.svg';
+
+const SpeakerDescription = styled.div`
+  display: none;
+  flex-direction: column;
+  justify-content: space-between;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1.25rem;
+  background-color: ${({ theme }) => transparentize(0.5, theme.palette.generics.black)};
+  color: ${({ theme }) => theme.palette.text};
+  font-size: 0.8rem;
+`;
+
+export const SpeakerContainer = styled.div`
+  width: 12.5rem;
+  height: 19rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: stretch;
+
+  &:hover {
+    ${SpeakerDescription} {
+      display: flex;
+    }
+  }
+`;
+
+export const SpeakerName = styled.div`
+  height: 6.25rem;
+  padding: 0 1.25rem;
+  display: flex;
+  align-items: center;
+  font-size: 1.75rem;
+  font-weight: bold;
+  color: ${({ theme }) => theme.palette.text};
+`;
+
+export const SpeakerPhoto = styled.div`
+  position: relative;
+  height: 12.35rem;
+  overflow: hidden;
+
+  & > img {
+    object-fit: cover;
+  }
+`;
+
+export const SpeakerTwitterLink = styled.a`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  color: ${({ theme }) => theme.palette.text};
+  opacity: 0.5;
+  text-decoration: none;
+
+  & > img {
+    height: 1.25rem;
+    margin-right: 0.75rem;
+  }
+`;
+
+export const Speaker = ({ firstName, lastName, image, description, twitterHandle }) => (
+  <SpeakerContainer>
+    <SpeakerName>
+      {firstName}
+      <br />
+      {lastName}
+    </SpeakerName>
+    <SpeakerPhoto>
+      <img src={image} alt={`foto de ${firstName} ${lastName}`} />
+      <SpeakerDescription>
+        <div>{description}</div>
+        {twitterHandle ? (
+          <SpeakerTwitterLink href={`https://twitter.com/${twitterHandle}`}>
+            <img alt="twitter icon" src={TwitterIcon} />
+            {twitterHandle}
+          </SpeakerTwitterLink>
+        ) : null}
+      </SpeakerDescription>
+    </SpeakerPhoto>
+  </SpeakerContainer>
+);
+
+Speaker.propTypes = {
+  firstName: PropTypes.string.isRequired,
+  lastName: PropTypes.string.isRequired,
+  image: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  twitterHandle: PropTypes.string,
+  reverse: PropTypes.bool
+};
+
+Speaker.defaultProps = {
+  twitterHandle: null,
+  reverse: false
+};

--- a/lib/SpeakerGrid/Speaker.jsx
+++ b/lib/SpeakerGrid/Speaker.jsx
@@ -17,6 +17,10 @@ const SpeakerDescription = styled.div`
   background-color: ${({ theme }) => transparentize(0.5, theme.palette.generics.black)};
   color: ${({ theme }) => theme.palette.text};
   font-size: 0.8rem;
+
+  @media (min-width: ${({ theme }) => theme.breakpoints.smallScreen}) {
+    font-size: 1.2rem;
+  }
 `;
 
 export const SpeakerContainer = styled.div`
@@ -31,6 +35,11 @@ export const SpeakerContainer = styled.div`
     ${SpeakerDescription} {
       display: flex;
     }
+  }
+
+  @media (min-width: ${({ theme }) => theme.breakpoints.smallScreen}) {
+    width: 18.75rem;
+    height: 28.5rem;
   }
 `;
 
@@ -51,6 +60,10 @@ export const SpeakerPhoto = styled.div`
 
   & > img {
     object-fit: cover;
+  }
+
+  @media (min-width: ${({ theme }) => theme.breakpoints.smallScreen}) {
+    height: 21.9rem;
   }
 `;
 

--- a/lib/SpeakerGrid/SpeakerGrid.jsx
+++ b/lib/SpeakerGrid/SpeakerGrid.jsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import { SpeakerContainer, SpeakerName } from './Speaker';
+
+export const SpeakerGrid = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  &:hover {
+    ${SpeakerContainer} {
+      opacity: 0.5;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
+
+  ${SpeakerContainer} {
+    margin-right: 0.4rem;
+    margin-bottom: 0.4rem;
+  }
+
+  ${SpeakerContainer}:nth-of-type(even) {
+    flex-direction: column-reverse;
+  }
+
+  ${SpeakerContainer}:nth-of-type(3n + 1) {
+    ${SpeakerName} {
+      background-color: ${({ theme }) => theme.palette.secondary};
+    }
+  }
+
+  ${SpeakerContainer}:nth-of-type(3n + 2) {
+    ${SpeakerName} {
+      background-color: ${({ theme }) => theme.palette.generics.black};
+    }
+  }
+
+  ${SpeakerContainer}:nth-of-type(3n + 3) {
+    ${SpeakerName} {
+      background-color: ${({ theme }) => theme.palette.primary};
+    }
+  }
+`;

--- a/lib/SpeakerGrid/SpeakerGrid.jsx
+++ b/lib/SpeakerGrid/SpeakerGrid.jsx
@@ -2,9 +2,10 @@ import styled from 'styled-components';
 import { SpeakerContainer, SpeakerName } from './Speaker';
 
 export const SpeakerGrid = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 12.5rem);
+  grid-column-gap: 0.4rem;
+  grid-row-gap: 0.4rem;
 
   &:hover {
     ${SpeakerContainer} {
@@ -14,11 +15,6 @@ export const SpeakerGrid = styled.div`
         opacity: 1;
       }
     }
-  }
-
-  ${SpeakerContainer} {
-    margin-right: 0.4rem;
-    margin-bottom: 0.4rem;
   }
 
   ${SpeakerContainer}:nth-of-type(even) {
@@ -41,5 +37,11 @@ export const SpeakerGrid = styled.div`
     ${SpeakerName} {
       background-color: ${({ theme }) => theme.palette.primary};
     }
+  }
+
+  @media (min-width: ${({ theme }) => theme.breakpoints.smallScreen}) {
+    grid-template-columns: repeat(auto-fill, 18.75rem);
+    grid-column-gap: 0.6rem;
+    grid-row-gap: 0.6rem;
   }
 `;

--- a/lib/SpeakerGrid/index.js
+++ b/lib/SpeakerGrid/index.js
@@ -1,0 +1,2 @@
+export { Speaker } from './Speaker';
+export { SpeakerGrid } from './SpeakerGrid';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 export { Input } from './Input';
 export { Button, CTALeafLike } from './Button';
 export { ValidationError, ValidationMessage } from './Validation';
+export { SpeakerGrid, Speaker } from './SpeakerGrid';

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -20,7 +20,8 @@ const theme = {
     }
   },
   breakpoints: {
-    mobile: '45rem'
+    mobile: '45rem',
+    smallScreen: '80rem'
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gatsby-transformer-sharp": "^2.1.13",
     "leaflet": "^1.4.0",
     "moment": "^2.24.0",
+    "polished": "^3.1.0",
     "ramda": "^0.26.1",
     "re-reselect": "^3.0.0",
     "react": "^16.8.0",

--- a/src/data/constants/menu.js
+++ b/src/data/constants/menu.js
@@ -7,12 +7,10 @@ export const MENU = [
     title: 'La conferencia',
     url: '/about/'
   },
-  /*
-   * {
-   *   title: 'Disertantes',
-   *   url: '/speakers'
-   * },
-   */
+  {
+    title: 'Disertantes',
+    url: '/speakers/'
+  },
   {
     title: 'Lugar',
     url: '/venue/'

--- a/src/layouts/landing/styles.module.scss
+++ b/src/layouts/landing/styles.module.scss
@@ -12,7 +12,7 @@
 
 .logo {
   @media (min-width: $theme-breakpoints-mobile) {
-    margin-bottom: 3rem;
+    margin-bottom: 2rem;
   }
 }
 
@@ -50,7 +50,7 @@
   }
 
   @media (min-width: $theme-breakpoints-mobile) {
-    margin: 3rem 0 2rem;
+    margin: 2rem 0;
     padding-left: 3.125rem;
     flex-direction: column;
     justify-content: flex-end;

--- a/src/layouts/landing/styles.module.scss
+++ b/src/layouts/landing/styles.module.scss
@@ -50,7 +50,7 @@
   }
 
   @media (min-width: $theme-breakpoints-mobile) {
-    margin: 2rem 0;
+    margin: 1.5rem 0;
     padding-left: 3.125rem;
     flex-direction: column;
     justify-content: flex-end;
@@ -59,7 +59,7 @@
     .newsletter-form {
       display: block;
       margin-right: 0;
-      margin-bottom: 3.5rem;
+      margin-bottom: 2rem;
     }
   }
 }

--- a/src/layouts/section/styles.module.scss
+++ b/src/layouts/section/styles.module.scss
@@ -45,7 +45,7 @@
 
   @media (min-width: $theme-breakpoints-mobile) {
     display: block;
-    margin-bottom: 3rem;
+    margin-bottom: 2rem;
   }
 }
 
@@ -112,7 +112,7 @@
   }
 
   @media (min-width: $theme-breakpoints-mobile) {
-    margin: 3rem 0 2rem;
+    margin: 2rem 0;
     padding-left: 3.125rem;
     flex-direction: column;
     justify-content: flex-end;

--- a/src/layouts/section/styles.module.scss
+++ b/src/layouts/section/styles.module.scss
@@ -112,7 +112,7 @@
   }
 
   @media (min-width: $theme-breakpoints-mobile) {
-    margin: 2rem 0;
+    margin: 1.5rem 0;
     padding-left: 3.125rem;
     flex-direction: column;
     justify-content: flex-end;
@@ -121,7 +121,7 @@
     .newsletter-form {
       display: block;
       margin-right: 0;
-      margin-bottom: 3.5rem;
+      margin-bottom: 2rem;
     }
   }
 }

--- a/src/pages/speakers.jsx
+++ b/src/pages/speakers.jsx
@@ -5,9 +5,9 @@ import { SpeakerGrid, Speaker } from 'lib';
 import styles from './speakers.module.scss';
 
 const SpeakersPage = () => (
-  <SectionLayout title="disertantes">
+  <SectionLayout title="disertantes" className={styles.section}>
     <SectionTitle>Disertantes</SectionTitle>
-    <SpeakerGrid className={styles.speakersGrid}>
+    <SpeakerGrid className={styles.grid}>
       <Speaker
         firstName="Agus"
         lastName="Carrasco"

--- a/src/pages/speakers.jsx
+++ b/src/pages/speakers.jsx
@@ -1,9 +1,28 @@
 import React from 'react';
+import Photo from 'assets/images/banner-background-mobile.png';
 import SectionLayout, { SectionTitle } from 'layouts/section';
+import { SpeakerGrid, Speaker } from 'lib';
+import styles from './speakers.module.scss';
 
 const SpeakersPage = () => (
   <SectionLayout title="disertantes">
     <SectionTitle>Disertantes</SectionTitle>
+    <SpeakerGrid className={styles.speakersGrid}>
+      <Speaker
+        firstName="Agus"
+        lastName="Carrasco"
+        image={Photo}
+        description="test description"
+        twitterHandle="asermax"
+      />
+      <Speaker firstName="Agus" lastName="Carrasco" image={Photo} description="test description" />
+      <Speaker firstName="Agus" lastName="Carrasco" image={Photo} description="test description" />
+      <Speaker firstName="Agus" lastName="Carrasco" image={Photo} description="test description" />
+      <Speaker firstName="Agus" lastName="Carrasco" image={Photo} description="test description" />
+      <Speaker firstName="Agus" lastName="Carrasco" image={Photo} description="test description" />
+      <Speaker firstName="Agus" lastName="Carrasco" image={Photo} description="test description" />
+      <Speaker firstName="Agus" lastName="Carrasco" image={Photo} description="test description" />
+    </SpeakerGrid>
   </SectionLayout>
 );
 

--- a/src/pages/speakers.jsx
+++ b/src/pages/speakers.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SectionLayout, { SectionTitle } from 'layouts/section';
+
+const SpeakersPage = () => (
+  <SectionLayout title="disertantes">
+    <SectionTitle>Disertantes</SectionTitle>
+  </SectionLayout>
+);
+
+export default SpeakersPage;

--- a/src/pages/speakers.module.scss
+++ b/src/pages/speakers.module.scss
@@ -1,0 +1,4 @@
+.speakers-grid {
+  margin-left: 5rem;
+  max-width: 52rem;
+}

--- a/src/pages/speakers.module.scss
+++ b/src/pages/speakers.module.scss
@@ -9,6 +9,7 @@
   min-width: 25.4rem;
 
   @media (min-width: $theme-breakpoints-mobile) {
+    width: 100%;
     align-self: flex-start;
     margin: 0 0 0 5rem;
     max-width: 52rem;

--- a/src/pages/speakers.module.scss
+++ b/src/pages/speakers.module.scss
@@ -1,4 +1,20 @@
-.speakers-grid {
-  margin-left: 5rem;
-  max-width: 52rem;
+.section {
+  display: flex;
+  flex-direction: column;
+}
+
+.grid {
+  align-self: center;
+  margin: 1rem 0;
+  min-width: 25.4rem;
+
+  @media (min-width: $theme-breakpoints-mobile) {
+    align-self: flex-start;
+    margin: 0 0 0 5rem;
+    max-width: 52rem;
+  }
+
+  @media (min-width: $theme-breakpoints-smallScreen) {
+    max-width: 77rem;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,6 +725,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.4.2":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
+  integrity sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -8796,6 +8803,13 @@ pnp-webpack-plugin@^1.4.1:
   dependencies:
     ts-pnp "^1.0.0"
 
+polished@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.1.0.tgz#8f77221e1a72885931da6d56e2bc3131a027c47a"
+  integrity sha512-b/5/QSn49Diy+kxPCIczxOz0YEX/j/XOc/QNFyKz3TcMymQpCILgYyqMDqPa4HoDCVq1bJgHamhR2gFGrIfLug==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+
 portfinder@^1.0.9:
   version "1.0.20"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.20.tgz#bea68632e54b2e13ab7b0c4775e9b41bf270e44a"
@@ -9771,6 +9785,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.13.3:
   version "0.13.3"


### PR DESCRIPTION
## What does this PR do?
This PR adds the speakers section to the site.
Right now it's only a placeholder, we need to start adding the data on it.

### 1: Speaker Grid component
The main addition is a grid for speakers:

![image](https://user-images.githubusercontent.com/1452164/55929688-2d335f00-5bf4-11e9-996b-fbba192baced.png)

### 2: New breakpoint for big screens
This PR adds an extra breakpoint  at `80rem` for bigger screens. This new breakpoint is currently only used on the speaker section to increase the size of the speakers grid.

## How should it be tested manually?
Open the deployment and go to the speakers section.