### PR TITLE
Disable bulk purchases

### DIFF
--- a/src/components/TicketValidationMessage/TicketValidationMessage.jsx
+++ b/src/components/TicketValidationMessage/TicketValidationMessage.jsx
@@ -35,8 +35,6 @@ const _TicketValidationMessage = ({
       message = (
         <>
           ¡Todo listo por aquí! Presioná&nbsp;
-          <em>Quiero otra</em>
-          &nbsp;o&nbsp;
           <em>Pagar</em>
           &nbsp;para continuar.
         </>

--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -4,7 +4,6 @@ import { navigate } from 'gatsby';
 import { isPurchaseCreated } from 'data/checkout/selectors';
 import { CheckoutMenu } from 'components/Menu';
 import SectionLayout, { SectionTitle } from 'layouts/section';
-import { TicketSelector } from 'components/TicketSelector';
 import { TicketForm } from 'components/TicketForm';
 import styles from './index.module.scss';
 
@@ -40,7 +39,6 @@ const CheckoutPage = ({ alreadyInitiated }) => {
     >
       <SectionTitle>Entradas</SectionTitle>
       <div className={styles.tickets}>
-        <TicketSelector />
         <TicketForm />
       </div>
     </SectionLayout>

--- a/src/pages/checkout/index.module.scss
+++ b/src/pages/checkout/index.module.scss
@@ -11,4 +11,7 @@
   @media (min-width: $theme-breakpoints-mobile) {
     margin-left: 7rem;
   }
+  @media (max-width: $theme-breakpoints-mobile) {
+    padding-top: 1.25rem;
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Hides the ticket selector so the users will only be able to purchase one ticket at a time. It also modifies the styles of the checkout package to add some padding where the ticket selector used to be.

## How should it be tested manually?

Go to `/checkout`, you shouldn't be able to fill up the form for more than one ticket.

## ToDo

- [x] @joelalejandro Should we change the title and the menu option to `Entrada` (we remove the plural)?
